### PR TITLE
Fix extension default values

### DIFF
--- a/lib/middleman/gh_pages/extension.rb
+++ b/lib/middleman/gh_pages/extension.rb
@@ -2,7 +2,7 @@ module Middleman
   module GhPages
     class Extension < Middleman::Extension
       option :remote, nil
-      option :branch, 'gh_pages'
+      option :branch, 'gh-pages'
 
       def initialize(app, options_hash = {}, &block)
         super


### PR DESCRIPTION
To keep compatibility with GitHub Pages defaults, the value of the branch option must be `gh-pages`.

fixes #2 